### PR TITLE
Support custom js snippets & favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Should you choose to add custom js snippet, create a `layouts/partials` folder w
 
 This can be useful for adding [Google Analytics](https://gohugo.io/extras/analytics/). Just add `{{ template "_internal/google_analytics.html" . }}` to the file and configure the config file with your `googleAnalytics` tracking id.
 
+## Customize favicon.ico
+
+You can customize a `favicon.ico` by adding it to `static` folder.
+
 ## License
 
 This theme is released under the CC BY 3.0 license. For more information, read the [License](https://github.com/sethmacleod/aerial/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ The Scrolling Background:
         of your image. Change $bg-width if your image is something other than
         1500px wide.
 
+### Add custom js snippets
+
+Should you choose to add custom js snippet, create a `layouts/partials` folder with `js.html` file and put your js code in this file.
+
+This can be useful for adding [Google Analytics](https://gohugo.io/extras/analytics/). Just add `{{ template "_internal/google_analytics.html" . }}` to the file and configure the config file with your `googleAnalytics` tracking id.
+
 ## License
 
 This theme is released under the CC BY 3.0 license. For more information, read the [License](https://github.com/sethmacleod/aerial/blob/master/LICENSE.md).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,7 @@ languageCode = "en-us"
 title = "Aerial"
 baseurl = "http://example.org/"
 theme = "aerial"
+favicon = "favicon.ico"
 
 [params]
   name = "Adam Jensen"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,6 +13,10 @@
 		<link rel="stylesheet" href="css/main.css" />
 		<!--[if lte IE 8]><link rel="stylesheet" href="css/ie8.css" /><![endif]-->
 		<!--[if lte IE 9]><link rel="stylesheet" href="css/ie9.css" /><![endif]-->
+    {{ with .Site.Params.favicon }}
+     <link rel="shortcut icon" type="image/x-icon" href="{{ . | absURL }}">
+     <link rel="icon" type="image/x-icon" href="{{ . | absURL }}">
+    {{ end }}
 	</head>
 	<body class="loading">
 		<div id="wrapper">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -46,5 +46,7 @@
 			window.ontouchmove = function() { return false; }
 			window.onorientationchange = function() { document.body.scrollTop = 0; }
 		</script>
+
+    {{ partial "js.html" . }}
 	</body>
 </html>


### PR DESCRIPTION
Adding support for:
1. custom snippets which can be used for adding google analytics for example.
2. favicon

**What did I change?**
1. Added a `js.html` partial to `index.html` 
2. Added favicon to `index.html` (only if set)
3. Added default favicon setup to `config.toml`
4. Updated `README.md`